### PR TITLE
Feature: Add .count() function to JSON response captures

### DIFF
--- a/src/Pororoca.Domain/Features/VariableCapture/PororocaResponseValueCapturer.cs
+++ b/src/Pororoca.Domain/Features/VariableCapture/PororocaResponseValueCapturer.cs
@@ -38,6 +38,8 @@ public static partial class PororocaResponseValueCapturer
 
             foreach (string subpath in subpaths)
             {
+                if (subpath.Equals("count()", StringComparison.InvariantCultureIgnoreCase))
+                    return GetCount(jsonNode);
                 if (IsArrayElementSubpath(subpath, out string? elementName, out int? index1, out int? index2))
                 {
                     if (elementName?.Equals("$", StringComparison.InvariantCultureIgnoreCase) == true)
@@ -103,5 +105,11 @@ public static partial class PororocaResponseValueCapturer
             index1 = index2 = null;
             return false;
         }
+    }
+
+    private static string GetCount(JsonNode node)
+    {
+        var count = node.AsArray().Count();
+        return count.ToString();
     }
 }

--- a/tests/Pororoca.Domain.Tests/Features/VariableCapture/PororocaResponseValueCapturerTests.cs
+++ b/tests/Pororoca.Domain.Tests/Features/VariableCapture/PororocaResponseValueCapturerTests.cs
@@ -91,6 +91,13 @@ public static partial class PororocaResponseValueCapturerTests
         Assert.Equal(expectedCapture, CaptureJsonValue(path, json));
 
     [Theory]
+    [InlineData("2", "$.count()", testJsonArr)]
+    [InlineData("3", "$.myObj.myObj2.arr.count()", testJsonObj)]
+    [InlineData(null, "$.myObj.count()", testJsonObj)]
+    public static void TestJsonValueCaptureCountFunction(string? expectedCapture, string path, string json) =>
+        Assert.Equal(expectedCapture, CaptureJsonValue(path, json));
+
+    [Theory]
     [InlineData("ABC", "/a", "<a>ABC</a>")]
     [InlineData("ENG", "/SessionInfo/Language", testXmlSimpleObj)]
     [InlineData("1", "/SessionInfo/Version", testXmlSimpleObj)]


### PR DESCRIPTION
Add .count() function to JSON response captures.
This is the first function from issue #86.