### PR TITLE
Fix TextEditor on HTTP request page not being completely visible

### DIFF
--- a/src/Pororoca.Desktop/TextEditorConfig/TextEditorConfiguration.cs
+++ b/src/Pororoca.Desktop/TextEditorConfig/TextEditorConfiguration.cs
@@ -39,7 +39,7 @@ internal static class TextEditorConfiguration
         editor.TextArea.RightClickMovesCaret = true;
         editor.TextArea.TextView.LinkTextForegroundBrush = PororocaThemeManager.MapLinkColourForEditorTheme(PororocaThemeManager.CurrentTheme);
 
-        var textMateInstallation = editor.InstallTextMate(DefaultRegistryOptions.Value!);
+        var textMateInstallation = editor.InstallTextMate(DefaultRegistryOptions.Value!, false);
         // the line below must be added only after the TextMate installation above
         // otherwise, the pororoca variable highlighting may be bugged
         if (applyPororocaVariableHighlighting)

--- a/src/Pororoca.Desktop/TextEditorConfig/TextEditorConfiguration.cs
+++ b/src/Pororoca.Desktop/TextEditorConfig/TextEditorConfiguration.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -36,6 +37,7 @@ internal static class TextEditorConfiguration
         editor.Options.EnableEmailHyperlinks = true;
         editor.Options.EnableHyperlinks = true;
         editor.TextArea.IndentationStrategy = new AvaloniaEdit.Indentation.DefaultIndentationStrategy();
+        editor.GetObservable(Visual.BoundsProperty).Subscribe(bounds => editor.TextArea.Width = bounds.Width);
         editor.TextArea.RightClickMovesCaret = true;
         editor.TextArea.TextView.LinkTextForegroundBrush = PororocaThemeManager.MapLinkColourForEditorTheme(PororocaThemeManager.CurrentTheme);
 

--- a/src/Pororoca.Desktop/Views/HttpRequestView.xaml
+++ b/src/Pororoca.Desktop/Views/HttpRequestView.xaml
@@ -267,7 +267,7 @@
                   Grid.Row="1"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch"
-                  Margin="0,12,0,0"
+                  Margin="12,12,12,0"
                   IsReadOnly="False"
                   Document="{Binding RequestRawContentTextDocument, Mode=TwoWay}"
                   IsVisible="{Binding RequestBodyModeSelectedIndex,
@@ -672,6 +672,7 @@
                   Grid.Row="0"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch"
+                  Margin="12,0,12,0"
                   IsReadOnly="True"
                   Document="{Binding ResponseDataCtx.ResponseRawContentTextDocument, Mode=TwoWay}"/>
               <StackPanel


### PR DESCRIPTION
I noticed that the text editor for the content or response of an HTTP request was not cut-off at the right edge. After some investigation this seems to be due to the negative margins of the parent grid, adding positive margins to the text editor fixed this.

However, the control would then not take up the entire available width and dynamically expanded before actually showing the scrollbar. I fixed this by force setting the text editor width to the bounds width, whenever the bounds changed. I am not very familiar with Avalonia, so there might be a better way to do this.

Let me know if you want me to drop the first commit or make a separate PR for it as it is unrelated to the rest of this PR. It avoids a (caught) exception in InstallTextMate due to the editor document always being null at construction.

This fixes #101. 