### PR TITLE
feat: resolve templates recursively with cycle detection

### DIFF
--- a/tests/Pororoca.Domain.Tests/Features/VariableResolution/IPororocaVariableResolverTests.cs
+++ b/tests/Pororoca.Domain.Tests/Features/VariableResolution/IPororocaVariableResolverTests.cs
@@ -59,6 +59,23 @@ public static class IPororocaVariableResolverTests
         // THEN
         Assert.Equal($"Today is {todayStr}", resolvedString);
     }
+    
+     [Fact]
+    public static void Should_replace_recursive_variables_correctly()
+    {
+        // GIVEN
+        PororocaCollection col = new(string.Empty);
+        col.Variables.Add(new(true, "FirstName", "John", false));
+        col.Variables.Add(new(true, "LastName", "McClane", false));
+        col.Variables.Add(new(true, "FullName", "{{ FirstName }} {{ LastName }}", false));
+
+        // WHEN
+        var effectiveVars = ((IPororocaVariableResolver)col).GetEffectiveVariables();
+        string resolvedString = IPororocaVariableResolver.ReplaceTemplates("{{ FullName }}", effectiveVars);
+
+        // THEN
+        Assert.Equal("John McClane", resolvedString);
+    }
 
     #endregion
 


### PR DESCRIPTION
- expand nested or chained variables without infinite loops
- track processed keys to prevent cycles and halt on self-references
- add unit test covering multi-level variable expansion