### PR TITLE
Add libicu75 and libicu76 to Debian package dependencies

### DIFF
--- a/src/Pororoca.Desktop.Debian/control
+++ b/src/Pororoca.Desktop.Debian/control
@@ -4,7 +4,7 @@ Section: devel
 Priority: optional
 Architecture: amd64
 Installed-Size: 68279
-Depends: libx11-6, libice6, libsm6, libfontconfig1, ca-certificates, tzdata, libc6, libgcc1 | libgcc-s1, libgssapi-krb5-2, libstdc++6, zlib1g, libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3, libicu | libicu74 | libicu72 | libicu71 | libicu70 | libicu69 | libicu68 | libicu67 | libicu66 | libicu65 | libicu63 | libicu60 | libicu57 | libicu55 | libicu52
+Depends: libx11-6, libice6, libsm6, libfontconfig1, ca-certificates, tzdata, libc6, libgcc1 | libgcc-s1, libgssapi-krb5-2, libstdc++6, zlib1g, libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3, libicu | libicu76 | libicu75 | libicu74 | libicu72 | libicu71 | libicu70 | libicu69 | libicu68 | libicu67 | libicu66 | libicu65 | libicu63 | libicu60 | libicu57 | libicu55 | libicu52
 Maintainer: Alexandre H. T. R. Bonfitto <alexandrehtrb@outlook.com>
 Homepage: https://pororoca.io
 Description: This is Pororoca, a HTTP inspection tool, for Debian-related distros.


### PR DESCRIPTION
## Summary

- Adds `libicu75` and `libicu76` as accepted dependency alternatives in the Debian control file
- Fixes installation on Ubuntu 25.04+ and 25.10 (Questing Quokka), which ship with libicu76

Fixes #188

## Test plan

- [ ] Install the resulting `.deb` package on Ubuntu 25.10 with libicu76
- [ ] Verify the package still installs correctly on older Ubuntu/Debian versions