### PR TITLE
Disable RPM signing

### DIFF
--- a/.github/workflows/cicd-wfw.yml
+++ b/.github/workflows/cicd-wfw.yml
@@ -236,44 +236,7 @@ jobs:
         # Create certs directory
         $certsDir = Join-Path (Get-Location) "certs"
         [void](New-Item $certsDir -ItemType Directory -ErrorAction Ignore);
-
-        # Import keys without prompting user input (for CI / CD)
-        # https://d.sb/2016/11/gpg-inappropriate-ioctl-for-device-errors
-        #   use-agent, pinentry-mode --> no ask for user input
-        #   allow-loopback-pinentry --> use TTY terminal, no ask for user input
-        #   allow-preset-passphrase --> set fixed passphrase, no ask for user input
         
-        $gpgDir = Join-Path $env:HOME ".gnupg"
-        [void](New-Item $gpgDir -ItemType Directory -ErrorAction Ignore);
-        chmod 700 $gpgDir
-
-        $gpgConfFilePath = Join-Path $env:HOME ".gnupg" "gpg.conf"
-        $gpgConfFileContent = @"
-        use-agent
-        pinentry-mode loopback
-        "@
-        echo $gpgConfFileContent >> $gpgConfFilePath
-        chmod 600 $gpgConfFilePath
-
-        $gpgAgentConfFilePath = Join-Path $env:HOME ".gnupg" "gpg-agent.conf"
-        $gpgAgentConfFileContent = @"
-        allow-loopback-pinentry
-        allow-preset-passphrase
-        "@
-        echo $gpgAgentConfFileContent >> $gpgAgentConfFilePath
-        chmod 600 $gpgAgentConfFilePath
-
-        # Fix ~/.gnupg directory permissions
-        chown -R $(whoami) $gpgDir
-
-        # Restart GPG agent
-        Write-Host "Restarting GPG agent..."
-        gpg-connect-agent RELOADAGENT /bye
-
-        # Set default passphrase for private key
-        Write-Host "Setting default preset passphrase for GPG..."
-        echo "${env:ALEXANDREHTRB_GPG_PRIVATE_KEY_PASSWORD}" | /usr/lib/gnupg2/gpg-preset-passphrase --preset "${env:ALEXANDREHTRB_GPG_KEYGRIP}"
-
         # Import public and private keys
         $publicKeyFilePath = Join-Path $certsDir "public-key.gpg"
         $privateKeyFilePath = Join-Path $certsDir "private-key.gpg"

--- a/.github/workflows/cicd-wfw.yml
+++ b/.github/workflows/cicd-wfw.yml
@@ -666,8 +666,8 @@ jobs:
 
     # code below taken from:
     # https://oneuptime.com/blog/post/2026-03-04-sign-verify-rpm-packages-gpg-rhel-9/view
-    - name: Sign RHEL and SUSE packages
-      if: ${{ inputs.runCD && inputs.produceDesktopLinuxInstallersX64 }}
+    - name: Sign RHEL and SUSE packages (DISABLED)
+      if: ${{ false && inputs.runCD && inputs.produceDesktopLinuxInstallersX64 }}
       shell: pwsh
       run: |        
         # Create .rpmmacros file
@@ -697,7 +697,7 @@ jobs:
         ALEXANDREHTRB_GPG_KEY_NAME: ${{ secrets.ALEXANDREHTRB_GPG_KEY_NAME }}
         ALEXANDREHTRB_GPG_PRIVATE_KEY_PASSWORD: ${{ secrets.ALEXANDREHTRB_GPG_PRIVATE_KEY_PASSWORD }}
 
-    - name: Verify RHEL and SUSE packages signatures
+    - name: Verify RHEL and SUSE packages signatures (DISABLED)
       if: ${{ false && inputs.runCD && inputs.produceDesktopLinuxInstallersX64 }}
       shell: pwsh
       run: |

--- a/.github/workflows/cicd-wfw.yml
+++ b/.github/workflows/cicd-wfw.yml
@@ -544,8 +544,8 @@ jobs:
     
     # code below taken from:
     # https://github.com/git-ecosystem/git-credential-manager/blob/6847fba88b5adfd631e6a1163c91c2b316f52701/.github/workflows/release.yml
-    - name: Sign Debian / Ubuntu package
-      if: ${{ inputs.runCD && inputs.produceDesktopLinuxInstallersX64 }}
+    - name: Sign Debian / Ubuntu package (DISABLED)
+      if: ${{ false && inputs.runCD && inputs.produceDesktopLinuxInstallersX64 }}
       shell: bash # !!!
       run: |
         # Install debsigs

--- a/.github/workflows/cicd-wfw.yml
+++ b/.github/workflows/cicd-wfw.yml
@@ -560,6 +560,12 @@ jobs:
         chmod a+x patched-debsigs/debsigs &&
         echo "$PWD/patched-debsigs" >>$GITHUB_PATH
 
+        # Using gpg-agent with a pre-cached passphrase
+        # First, cache the passphrase
+        # Then sign the RPM (gpg-agent will use the cached passphrase)
+        echo "${env:ALEXANDREHTRB_GPG_PRIVATE_KEY_PASSWORD}" | gpg --batch --passphrase-fd 0 --pinentry-mode loopback --sign --armor /dev/null 2>/dev/null
+        $env:GPG_TTY="$(tty)"
+
         # Sign .deb file
         keyId="$(echo -n $ALEXANDREHTRB_GPG_KEY_FINGERPRINT | tail -c 16)"
         debFilePath="./out/Pororoca_${VERSION_NAME}_amd64.deb"
@@ -567,6 +573,7 @@ jobs:
         debsigs --sign=origin --default-key=$keyId $debFilePath
       env:
         ALEXANDREHTRB_GPG_KEY_FINGERPRINT: ${{ secrets.ALEXANDREHTRB_GPG_KEY_FINGERPRINT }}
+        ALEXANDREHTRB_GPG_PRIVATE_KEY_PASSWORD: ${{ secrets.ALEXANDREHTRB_GPG_PRIVATE_KEY_PASSWORD }}
 
     # code below taken from:
     # https://blog.packagecloud.io/how-to-gpg-sign-and-verify-deb-packages-and-apt-repositories/


### PR DESCRIPTION
DEB signing verification is not working and is not the main method of signature for Debian-family distros.

RPM signing **CORRUPTS** the RPM package for some reason.